### PR TITLE
Abstract session access more explicitly

### DIFF
--- a/microcosm_sqlite/dataset.py
+++ b/microcosm_sqlite/dataset.py
@@ -9,9 +9,6 @@ from sqlalchemy.ext.declarative import declarative_base
 from microcosm_sqlite.context import SessionContext
 
 
-SESSION = "__session__"
-
-
 class DataSet:
     """
     A base class for a declarative base, representing a set of related types.
@@ -42,22 +39,6 @@ class DataSet:
                 return base
 
         raise Exception(f"Not a valid DataSet: {cls}")
-
-    @property
-    def session(self):
-        """
-        Get the current session attached to this data set (if any)
-
-        """
-        return getattr(self.__class__.resolve(), SESSION, None)
-
-    @session.setter
-    def session(self, session):
-        """
-        Set the session attached to this data set.
-
-        """
-        setattr(self.__class__.resolve(), SESSION, session)
 
     @classmethod
     def create_all(cls, graph):

--- a/microcosm_sqlite/tests/test_threading.py
+++ b/microcosm_sqlite/tests/test_threading.py
@@ -1,0 +1,45 @@
+"""
+Threading tests.
+
+"""
+from multiprocessing.pool import ThreadPool
+from tempfile import NamedTemporaryFile
+
+from hamcrest import assert_that, contains
+from microcosm.api import create_object_graph
+from microcosm.loaders import load_from_dict
+
+from microcosm_sqlite.context import SessionContext
+from microcosm_sqlite.stores import GetOrCreateSession
+from microcosm_sqlite.tests.fixtures import Example, Person, PersonStore
+
+
+def test_threading():
+    with NamedTemporaryFile() as tmp_file:
+        loader = load_from_dict(
+            sqlite=dict(
+                paths=dict(
+                    example=tmp_file.name,
+                ),
+            ),
+        )
+        graph = create_object_graph("example", testing=True, loader=loader)
+        store = PersonStore()
+
+        Person.recreate_all(graph)
+
+        with SessionContext(graph, Example) as context:
+            gw = store.create(
+                Person(id=1, first="George", last="Washington"),
+            )
+            tj = store.create(
+                Person(id=2, first="Thomas", last="Jefferson"),
+            )
+            context.commit()
+
+        pool = ThreadPool(2)
+
+        store.get_session = GetOrCreateSession(graph)
+        people = pool.map(lambda index: store.search()[index], range(2))
+
+        assert_that(people, contains(gw, tj))


### PR DESCRIPTION
Key changes:
 -  Stores should access sessions through an explicit interface and not rely on
    opaque `getattr` magic.
 -  Store interface should support lazy-creation in addition to context-based access