### PR TITLE
Fix `Truthy` type to work with `NOT NULL` constraint + rollback on `IntegrityError`

### DIFF
--- a/microcosm_sqlite/stores.py
+++ b/microcosm_sqlite/stores.py
@@ -208,6 +208,8 @@ class Store(metaclass=ABCMeta):
             yield
             self.session.flush()
         except IntegrityError as error:
+            self.session.rollback()
+
             if "UNIQUE constraint failed" in str(error):
                 raise DuplicateModelError(error)
             raise ModelIntegrityError(error)

--- a/microcosm_sqlite/tests/test_stores.py
+++ b/microcosm_sqlite/tests/test_stores.py
@@ -57,6 +57,15 @@ class TestStore:
             raises(ModelIntegrityError),
         )
 
+    def test_create_after_intergrity_error(self):
+        assert_that(
+            calling(self.store.create).with_args(Person(id=3, first=None, last=None)),
+            raises(ModelIntegrityError),
+        )
+
+        # no exception is raised
+        self.store.create(Person(id=3, first="First", last="Last"))
+
     def test_create_duplicate_error(self):
         self.store.create(Person(id=3, first="First", last="Last"))
         self.context.commit()

--- a/microcosm_sqlite/tests/test_stores.py
+++ b/microcosm_sqlite/tests/test_stores.py
@@ -57,14 +57,15 @@ class TestStore:
             raises(ModelIntegrityError),
         )
 
-    def test_create_after_intergrity_error(self):
+    def test_create_after_integrity_error(self):
         assert_that(
             calling(self.store.create).with_args(Person(id=3, first=None, last=None)),
             raises(ModelIntegrityError),
         )
 
-        # no exception is raised
-        self.store.create(Person(id=3, first="First", last="Last"))
+        # create works after IntegrityError
+        self.store.create(self.gw)
+        assert_that(self.store.search(), contains(self.gw))
 
     def test_create_duplicate_error(self):
         self.store.create(Person(id=3, first="First", last="Last"))

--- a/microcosm_sqlite/tests/test_types.py
+++ b/microcosm_sqlite/tests/test_types.py
@@ -38,6 +38,7 @@ def test_truthy():
         (0, False),
         ("", False),
         ("0", False),
+        (None, None),
     ]
 
     graph = create_object_graph("example")

--- a/microcosm_sqlite/types.py
+++ b/microcosm_sqlite/types.py
@@ -16,6 +16,8 @@ class Truthy(TypeDecorator):
     impl = Boolean
 
     def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
         if isinstance(value, bool):
             return value
         if isinstance(value, str):


### PR DESCRIPTION
1. `Truthy` type is trying to infer value from `string` and if it fails it returns default of `bool(value)` - this makes `Truthy` incapable to be `NOT NULL` as `bool(None) == False`, so there is always a default value `False`.
2. When in the same context there appear an `IntegrityError` the first subsequent call to SQLite fails with `sqlalchemy.exc.InvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush.` - adding `rollback` in `except` block.