### PR TITLE
Disable `pysqlite` transaction management

### DIFF
--- a/microcosm_sqlite/tests/test_builders.py
+++ b/microcosm_sqlite/tests/test_builders.py
@@ -3,6 +3,7 @@ Test database building.
 
 """
 from io import StringIO
+from tempfile import NamedTemporaryFile
 from textwrap import dedent
 
 from hamcrest import (
@@ -31,9 +32,12 @@ def csv(s):
 class TestCSVBuilders:
 
     def setup(self):
+        self.tmp_file = NamedTemporaryFile()
         loader = load_from_dict(
             sqlite=dict(
-                taxonomy=":memory:",
+                paths=dict(
+                    taxonomy=self.tmp_file.name,
+                ),
             ),
         )
         self.graph = create_object_graph("example", testing=True, loader=loader)
@@ -56,6 +60,9 @@ class TestCSVBuilders:
              2,Reza,1
              3,Rookie,1
         """))
+
+    def terdown(self):
+        self.tmp_file.close()
 
     def test_build_with_csv_builder(self):
         self.builder.csv(Person).build(self.people)

--- a/microcosm_sqlite/tests/test_builders.py
+++ b/microcosm_sqlite/tests/test_builders.py
@@ -61,7 +61,7 @@ class TestCSVBuilders:
              3,Rookie,1
         """))
 
-    def terdown(self):
+    def teardown(self):
         self.tmp_file.close()
 
     def test_build_with_csv_builder(self):


### PR DESCRIPTION
It turned out, that because of some old bugs in `pysqlite`, `defer_foreign_keys` PRAGMA is not working correctly with connection pools different than `SingletonPool` (default pool for `:memory:` store).

Here's is a workaround that is partially disabling `pysqlite` transaction management - running `BEGIN` on appropriate sqlalchemy event, see: https://docs.sqlalchemy.org/en/latest/dialects/sqlite.html?highlight=sqlite#serializable-isolation-savepoints-transactional-ddl for more details.