### PR TITLE
Allow CSV builder to accept defaults

### DIFF
--- a/microcosm_sqlite/tests/test_builders.py
+++ b/microcosm_sqlite/tests/test_builders.py
@@ -200,3 +200,15 @@ class TestCSVBuilders:
                     ),
                 ),
             )
+
+    def test_build_with_csv_builder_default(self):
+        """
+        Known values can be defaulted (for entire CSVs)
+
+        """
+        people = csv(dedent("""
+            id,first
+             1,Stephen
+             2,Dell
+        """))
+        self.builder.csv(Person).default(last="Curry").build(people)


### PR DESCRIPTION
Enables CSVs to omit values that can be inferred from context but that are not global to the data model.

For example: we may have multiple CSVs organized into a directory tree where the directory name provides a column name that can be omitted from the CSV.