### PR TITLE
Avoid configuring DB paths via entry points in tests

### DIFF
--- a/microcosm_sqlite/factories.py
+++ b/microcosm_sqlite/factories.py
@@ -44,10 +44,14 @@ class SQLiteBindFactory:
         self.use_foreign_keys = strtobool(graph.config.sqlite.use_foreign_keys)
 
         self.datasets = dict()
-        self.paths = {
-            entry_point.name: entry_point.load()()
-            for entry_point in iter_entry_points("microcosm.sqlite")
-        }
+        if graph.metadata.testing:
+            self.paths = dict()
+        else:
+            # Avoid this when testing to default to in-memory DB
+            self.paths = {
+                entry_point.name: entry_point.load()()
+                for entry_point in iter_entry_points("microcosm.sqlite")
+            }
         self.paths.update(graph.config.sqlite.paths)
 
     def __getitem__(self, key):


### PR DESCRIPTION
Having the DB path configuration via an entry point allows a library user to load sqlite data without worrying about where the DB file is.
In unit tests however, it means that if we've defined an entry point to configure the path, that path will be used in the test unless we explicitly set SQLite to use an in-memory DB in the test config.
This is somehwat dangerous, since a test written by someone ignoring this could modify the actual DB that the library exports.