### PR TITLE
Release version 0.10.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.10.0
 commit = False
 tag = False
 

--- a/microcosm_sqlite/dumpers/__init__.py
+++ b/microcosm_sqlite/dumpers/__init__.py
@@ -1,0 +1,17 @@
+"""
+Dump SQLite databases to file.
+
+"""
+from microcosm_sqlite.dumpers.csv import CSVDumper
+
+
+class SQLiteDumper:
+    """
+    Top-level binding for SQLite database building.
+
+    """
+    def __init__(self, graph):
+        self.graph = graph
+
+    def csv(self, store, **kwargs):
+        return CSVDumper(self.graph, store, **kwargs)

--- a/microcosm_sqlite/dumpers/csv.py
+++ b/microcosm_sqlite/dumpers/csv.py
@@ -1,0 +1,41 @@
+"""
+CSV-based building.
+
+"""
+from csv import DictWriter
+
+
+class CSVDumper:
+    """
+    CSV-based builder for a single model class (non bulk mode)
+    and multi model class (bulk mode).
+
+    """
+    def __init__(
+        self,
+        graph,
+        model_cls,
+        bulk_mode=False,
+    ):
+        self.graph = graph
+        self.model_cls = model_cls
+        self.defaults = dict()
+
+    def default(self, **kwargs):
+        self.defaults.update(kwargs)
+        return self
+
+    def dump(self, fileobj):
+        writer = DictWriter(fileobj, fieldnames=self.get_columns())
+
+        writer.writeheader()
+
+        with self.model_cls.new_context(self.graph):
+            for item in self.model_cls.session.query(self.model_cls).all():
+                writer.writerow(item._members())
+
+    def get_columns(self):
+        return {
+            column.name: (key, column)
+            for key, column in self.model_cls.__mapper__.columns.items()
+        }

--- a/microcosm_sqlite/tests/test_builders.py
+++ b/microcosm_sqlite/tests/test_builders.py
@@ -36,7 +36,7 @@ class TestCSVBuilders:
         loader = load_from_dict(
             sqlite=dict(
                 paths=dict(
-                    taxonomy=self.tmp_file.name,
+                    example=self.tmp_file.name,
                 ),
             ),
         )

--- a/microcosm_sqlite/tests/test_dumpers.py
+++ b/microcosm_sqlite/tests/test_dumpers.py
@@ -1,0 +1,66 @@
+"""
+Test database building.
+
+"""
+from io import StringIO
+from tempfile import NamedTemporaryFile
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+)
+from microcosm.api import create_object_graph
+from microcosm.loaders import load_from_dict
+
+from microcosm_sqlite.tests.fixtures import (
+    Example,
+    Person,
+    PersonStore,
+)
+
+
+class TestCSVDumpers:
+
+    def setup(self):
+        self.tmp_file = NamedTemporaryFile()
+        loader = load_from_dict(
+            sqlite=dict(
+                paths=dict(
+                    example=self.tmp_file.name,
+                ),
+            ),
+        )
+        self.graph = create_object_graph("example", testing=True, loader=loader)
+        self.dumper = self.graph.sqlite_dumper
+
+        self.person_store = PersonStore()
+
+        Example.create_all(self.graph)
+
+        self.outfile = StringIO()
+        with Example.new_context(self.graph):
+            self.person_store.create(
+                Person(
+                    id="1",
+                    first="Stephen",
+                    last="Curry",
+                )
+            )
+            self.person_store.create(
+                Person(
+                    id="2",
+                    first="Klay",
+                    last="Thompson",
+                )
+            )
+            self.person_store.session.commit()
+
+    def teardown(self):
+        self.tmp_file.close()
+
+    def test_build_with_csv_builder(self):
+        self.dumper.csv(Person).dump(self.outfile)
+        assert_that(
+            self.outfile.getvalue(),
+            equal_to("id,first,last\r\n1,Stephen,Curry\r\n2,Klay,Thompson\r\n")
+        )

--- a/microcosm_sqlite/types.py
+++ b/microcosm_sqlite/types.py
@@ -2,8 +2,40 @@
 Custom types.
 
 """
+from enum import Enum
+
 from distutils.util import strtobool
-from sqlalchemy.types import Boolean, TypeDecorator
+from sqlalchemy.types import Boolean, TypeDecorator, Unicode
+
+
+class EnumType(TypeDecorator):
+    """
+    SQLAlchemy enum type that persists the enum name (not value).
+
+    Note that this type is very similar to the `ChoiceType` from `sqlalchemy_utils`,
+    with the key difference being persisting by name (and not value).
+
+    """
+    impl = Unicode(255)
+
+    def __init__(self, enum_class):
+        self.enum_class = enum_class
+
+    @property
+    def python_type(self):
+        return self.impl.python_type
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        if isinstance(value, Enum):
+            return str(self.enum_class(value).name)
+        return str(self.enum_class[value].name)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        return self.enum_class[value]
 
 
 class Truthy(TypeDecorator):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-sqlite"
-version = "0.9.0"
+version = "0.10.0"
 
 setup(
     name=project,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "microcosm.factories": [
             "sqlite = microcosm_sqlite.factories:SQLiteBindFactory",
             "sqlite_builder = microcosm_sqlite.builders:SQLiteBuilder",
+            "sqlite_dumper = microcosm_sqlite.dumpers:SQLiteDumper",
         ],
     },
     tests_require=[


### PR DESCRIPTION
- DB path configuration defaults to ":memory:" in test, ignoring entrypoint config
- New CSV dumper to save DB to CSV file