### PR TITLE
Revert "Avoid configuring DB paths via entry points in tests"

### DIFF
--- a/microcosm_sqlite/factories.py
+++ b/microcosm_sqlite/factories.py
@@ -44,14 +44,10 @@ class SQLiteBindFactory:
         self.use_foreign_keys = strtobool(graph.config.sqlite.use_foreign_keys)
 
         self.datasets = dict()
-        if graph.metadata.testing:
-            self.paths = dict()
-        else:
-            # Avoid this when testing to default to in-memory DB
-            self.paths = {
-                entry_point.name: entry_point.load()()
-                for entry_point in iter_entry_points("microcosm.sqlite")
-            }
+        self.paths = {
+            entry_point.name: entry_point.load()()
+            for entry_point in iter_entry_points("microcosm.sqlite")
+        }
         self.paths.update(graph.config.sqlite.paths)
 
     def __getitem__(self, key):


### PR DESCRIPTION
This reverts commit 7a372b3bf8d57837c0c49ed8d52bf6c458530f25.