### PR TITLE
Allow dumping only portion of a table to CSV

### DIFF
--- a/microcosm_sqlite/dumpers/csv.py
+++ b/microcosm_sqlite/dumpers/csv.py
@@ -25,13 +25,15 @@ class CSVDumper:
         self.defaults.update(kwargs)
         return self
 
-    def dump(self, fileobj):
+    def dump(self, fileobj, items=None):
+        if items is None:
+            items = self.model_cls.session.query(self.model_cls).all()
         writer = DictWriter(fileobj, fieldnames=self.get_columns())
 
         writer.writeheader()
 
         with self.model_cls.new_context(self.graph):
-            for item in self.model_cls.session.query(self.model_cls).all():
+            for item in items:
                 writer.writerow(item._members())
 
     def get_columns(self):

--- a/microcosm_sqlite/tests/test_dumpers.py
+++ b/microcosm_sqlite/tests/test_dumpers.py
@@ -54,13 +54,24 @@ class TestCSVDumpers:
                 )
             )
             self.person_store.session.commit()
+        self.context = Person.new_context(self.graph).open()
 
     def teardown(self):
         self.tmp_file.close()
 
-    def test_build_with_csv_builder(self):
+    def test_dump_with_csv_dump(self):
         self.dumper.csv(Person).dump(self.outfile)
         assert_that(
             self.outfile.getvalue(),
             equal_to("id,first,last\r\n1,Stephen,Curry\r\n2,Klay,Thompson\r\n")
+        )
+
+    def test_dump_selected_portion(self):
+        self.dumper.csv(Person).dump(
+            self.outfile,
+            items=self.person_store.search(first="Klay")
+        )
+        assert_that(
+            self.outfile.getvalue(),
+            equal_to("id,first,last\r\n2,Klay,Thompson\r\n")
         )


### PR DESCRIPTION
We may want to have only a subset of a table's items dumped into a specific file.