### PR TITLE
Fix query ordering

### DIFF
--- a/microcosm_sqlite/tests/test_except.py
+++ b/microcosm_sqlite/tests/test_except.py
@@ -1,0 +1,54 @@
+from tempfile import NamedTemporaryFile
+
+from hamcrest import assert_that, contains
+from microcosm.api import create_object_graph
+from microcosm.loaders import load_from_dict
+
+from microcosm_sqlite.context import SessionContext
+from microcosm_sqlite.tests.fixtures import (
+    Example,
+    Person,
+    PersonExclusionStore
+)
+
+
+def test_except():
+    with NamedTemporaryFile() as tmp_file:
+        # NB: not using :memory: sqlite database
+        # as it maintains single database connection
+        loader = load_from_dict(
+            sqlite=dict(
+                paths=dict(
+                    example=tmp_file.name,
+                ),
+            ),
+        )
+        graph = create_object_graph("example", testing=True, loader=loader)
+        store = PersonExclusionStore()
+
+        Person.recreate_all(graph)
+
+        person1 = Person(
+            id=1,
+            first="John",
+            last="Krakow",
+        )
+
+        person2 = Person(
+            id=2,
+            first="Susan",
+            last="Krakow",
+        )
+
+        with SessionContext(graph, Example):
+            store.create(person1)
+            store.create(person2)
+
+            assert_that(
+                store.search(
+                    last="Krakow",
+                    exclude_first="John",
+                    limit=5,
+                ),
+                contains(person2),
+            )

--- a/microcosm_sqlite/tests/test_stores.py
+++ b/microcosm_sqlite/tests/test_stores.py
@@ -28,28 +28,23 @@ class TestStore:
     def setup(self):
         self.graph = create_object_graph("example", testing=True)
 
-        self.gw = Person(id=1, first="George", last="Washington")
-        self.tj = Person(id=2, first="Thomas", last="Jefferson")
+        self.gc = Person(id=1, first="George", last="Clinton")
+        self.gw = Person(id=2, first="George", last="Washington")
+        self.rf = Person(id=3, first="Rosalind", last="Franklin")
         self.store = PersonStore()
 
         Person.recreate_all(self.graph)
         self.context = Person.new_context(self.graph).open()
 
     def populate(self):
-        self.store.create(self.tj)
         self.store.create(self.gw)
+        self.store.create(self.rf)
+        self.store.create(self.gc)
         self.context.commit()
 
     def teardown(self):
         self.context.close()
         Person.dispose(self.graph)
-
-    def test_count(self):
-        assert_that(self.store.count(), is_(equal_to(0)))
-
-        self.populate()
-
-        assert_that(self.store.count(), is_(equal_to(2)))
 
     def test_create_integrity_error(self):
         assert_that(
@@ -88,14 +83,31 @@ class TestStore:
             raises(ModelNotFoundError),
         )
 
-        assert_that(self.store.count(), is_(equal_to(1)))
+        assert_that(self.store.count(), is_(equal_to(2)))
+
+        self.store.delete()
+
+        assert_that(self.store.count(), is_(equal_to(0)))
+
+    def test_count(self):
+        assert_that(self.store.count(), is_(equal_to(0)))
+
+        self.populate()
+
+        assert_that(self.store.count(), is_(equal_to(3)))
+        assert_that(self.store.count(offset=1), is_(equal_to(2)))
+        assert_that(self.store.count(limit=1), is_(equal_to(1)))
+        assert_that(self.store.count(offset=1, limit=1), is_(equal_to(1)))
 
     def test_first(self):
         assert_that(self.store.first(), is_(none()))
 
         self.populate()
 
-        assert_that(self.store.first(), is_(equal_to(self.gw)))
+        assert_that(self.store.first(), is_(equal_to(self.gc)))
+        assert_that(self.store.first(offset=1), is_(equal_to(self.gw)))
+        assert_that(self.store.first(limit=1), is_(equal_to(self.gc)))
+        assert_that(self.store.first(offset=1, limit=1), is_(equal_to(self.gw)))
 
     def test_one(self):
         assert_that(
@@ -110,11 +122,40 @@ class TestStore:
             raises(MultipleModelsFoundError),
         )
 
-        assert_that(self.store.one(limit=1), is_(equal_to(self.gw)))
+        assert_that(
+            calling(self.store.one).with_args(first="George"),
+            raises(MultipleModelsFoundError),
+        )
+
+        assert_that(self.store.one(first="Rosalind"), is_(equal_to(self.rf)))
+        assert_that(self.store.one(limit=1), is_(equal_to(self.gc)))
+        assert_that(
+            self.store.one(first="George", offset=1),
+            is_(equal_to(self.gw))
+        )
+        assert_that(
+            self.store.one(offset=1, limit=1),
+            is_(equal_to(self.gw))
+        )
 
     def test_search(self):
         assert_that(self.store.search(), is_(empty()))
 
         self.populate()
 
-        assert_that(self.store.search(), contains(self.gw, self.tj))
+        assert_that(
+            self.store.search(),
+            contains(self.gc, self.gw, self.rf)
+        )
+        assert_that(
+            self.store.search(offset=1),
+            contains(self.gw, self.rf)
+        )
+        assert_that(
+            self.store.search(limit=2),
+            contains(self.gc, self.gw)
+        )
+        assert_that(
+            self.store.search(offset=1, limit=1),
+            contains(self.gw)
+        )


### PR DESCRIPTION
When using an `EXCEPT` clause within `_filter`, this clause needs to occur before the `_order_by`.  However, `_order_by` must occer before `limit`.  Thus, we put `_filter` before `_order_by`, and remove the `limit` and `offset` operations from `_filter`, instead doing them last.