### PR TITLE
Add SQLAlchemyUtils to microcosm-sqlite

### DIFF
--- a/microcosm_sqlite/identifiers.py
+++ b/microcosm_sqlite/identifiers.py
@@ -1,0 +1,13 @@
+"""
+Identifier utilities.
+
+"""
+from uuid import uuid4
+
+
+def new_object_id():
+    """
+    Use randomized UUIDs by default.
+
+    """
+    return uuid4()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         "microcosm>=2.0.0",
         "SQLAlchemy>=1.2.0",
+        "SQLAlchemy-Utils>=0.33.3",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
Why?

To support using UUIDType in SQLLite table.
Also add new_object_id for consistentcy in initializing ID's with microcosm-postgres