### PR TITLE
Add SQLAlchemyUtils to microcosm-sqlite

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.14.0
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 0.15.0
 commit = False
 tag = False
 

--- a/microcosm_sqlite/factories.py
+++ b/microcosm_sqlite/factories.py
@@ -32,6 +32,7 @@ def on_begin_listener(connection):
     path=":memory:",
     paths=dict(),
     use_foreign_keys="True",
+    autocommit=False,
 )
 class SQLiteBindFactory:
     """
@@ -42,6 +43,7 @@ class SQLiteBindFactory:
         self.default_path = graph.config.sqlite.path
         self.echo = strtobool(graph.config.sqlite.echo)
         self.use_foreign_keys = strtobool(graph.config.sqlite.use_foreign_keys)
+        self.autocommit = graph.config.sqlite.autocommit
 
         self.datasets = dict()
         self.paths = {
@@ -70,7 +72,7 @@ class SQLiteBindFactory:
             event.listen(engine, "connect", on_connect_listener(self.use_foreign_keys))
             event.listen(engine, "begin", on_begin_listener)
 
-            Session = sessionmaker(bind=engine)
+            Session = sessionmaker(bind=engine, autocommit=self.autocommit)
 
             self.datasets[name] = engine, Session
 

--- a/microcosm_sqlite/identifiers.py
+++ b/microcosm_sqlite/identifiers.py
@@ -1,0 +1,13 @@
+"""
+Identifier utilities.
+
+"""
+from uuid import uuid4
+
+
+def new_object_id():
+    """
+    Use randomized UUIDs by default.
+
+    """
+    return uuid4()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-sqlite"
-version = "0.14.0"
+version = "0.15.0"
 
 setup(
     name=project,

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         "microcosm>=2.0.0",
         "SQLAlchemy>=1.2.0",
+        "SQLAlchemy-Utils>=0.33.3",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-sqlite"
-version = "0.13.0"
+version = "0.14.0"
 
 setup(
     name=project,


### PR DESCRIPTION
Why?

To support using UUIDType in SQLite tables