### PR TITLE
Automatically include sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ docs/_build/
 target/
 
 coverage/
+
+.mypy_cache/

--- a/microcosm_sqlite/stores.py
+++ b/microcosm_sqlite/stores.py
@@ -34,6 +34,7 @@ def get_session(store):
 class GetOrCreateSession:
 
     def __init__(self, graph, expire_on_commit=False):
+        graph.use("sqlite")
         self.graph = graph
         self.expire_on_commit = expire_on_commit
 


### PR DESCRIPTION
This PR obviates the need to explicitly add `sqlite` as a dependency in libraries that use `GetOrCreateSession`.