### PR TITLE
Dropped sqlalchemy utils

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.25.0
+current_version = 0.26.0
 commit = False
 tag = False
 

--- a/microcosm_sqlite/types/__init__.py
+++ b/microcosm_sqlite/types/__init__.py
@@ -1,0 +1,3 @@
+from microcosm_postgres.types.enum import EnumType  # noqa: F401
+from microcosm_postgres.types.truthy import Truthy  # noqa: F401
+from microcosm_postgres.types.uuid import UUIDType  # noqa: F401

--- a/microcosm_sqlite/types/__init__.py
+++ b/microcosm_sqlite/types/__init__.py
@@ -1,3 +1,3 @@
-from microcosm_postgres.types.enum import EnumType  # noqa: F401
-from microcosm_postgres.types.truthy import Truthy  # noqa: F401
-from microcosm_postgres.types.uuid import UUIDType  # noqa: F401
+from microcosm_sqlite.types.enum import EnumType  # noqa: F401
+from microcosm_sqlite.types.truthy import Truthy  # noqa: F401
+from microcosm_sqlite.types.uuid import UUIDType  # noqa: F401

--- a/microcosm_sqlite/types/enum.py
+++ b/microcosm_sqlite/types/enum.py
@@ -1,11 +1,6 @@
-"""
-Custom types.
-
-"""
-from distutils.util import strtobool
 from enum import Enum
 
-from sqlalchemy.types import Boolean, TypeDecorator, Unicode
+from sqlalchemy.types import TypeDecorator, Unicode
 
 
 class EnumType(TypeDecorator):
@@ -36,24 +31,3 @@ class EnumType(TypeDecorator):
         if value is None:
             return None
         return self.enum_class[value]
-
-
-class Truthy(TypeDecorator):
-    """
-    Truthy-aware boolean value.
-
-    Supports string-valued inputs (and handles them as gracefully as possible)
-
-    """
-    impl = Boolean
-
-    def process_bind_param(self, value, dialect):
-        if value is None:
-            return None
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, str):
-            if not value:
-                return False
-            return strtobool(value)
-        return bool(value)

--- a/microcosm_sqlite/types/truthy.py
+++ b/microcosm_sqlite/types/truthy.py
@@ -1,0 +1,24 @@
+from distutils.util import strtobool
+
+from sqlalchemy.types import Boolean, TypeDecorator
+
+
+class Truthy(TypeDecorator):
+    """
+    Truthy-aware boolean value.
+
+    Supports string-valued inputs (and handles them as gracefully as possible)
+
+    """
+    impl = Boolean
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            if not value:
+                return False
+            return strtobool(value)
+        return bool(value)

--- a/microcosm_sqlite/types/uuid.py
+++ b/microcosm_sqlite/types/uuid.py
@@ -1,0 +1,102 @@
+"""
+Copyright (c) 2012, Konsta Vesterinen
+
+Code from SQLAlchemy-Utils moved here until the library will support SQLAlchemy >= 1.4
+Related github issue: https://github.com/kvesteri/sqlalchemy-utils/issues/505
+
+"""
+import uuid
+
+from sqlalchemy import types, util
+from sqlalchemy.dialects import mssql, postgresql
+
+
+class ScalarCoercible(object):
+    def _coerce(self, value):
+        raise NotImplementedError
+
+    def coercion_listener(self, target, value, oldvalue, initiator):
+        return self._coerce(value)
+
+
+class UUIDType(types.TypeDecorator, ScalarCoercible):
+    """
+    Stores a UUID in the database natively when it can and falls back to
+    a BINARY(16) or a CHAR(32) when it can't.
+
+    Usage
+
+        from sqlalchemy_utils import UUIDType
+        import uuid
+
+        class User(Base):
+            __tablename__ = 'user'
+
+            # Pass `binary=False` to fallback to CHAR instead of BINARY
+            id = sa.Column(UUIDType(binary=False), primary_key=True)
+
+    """
+    impl = types.BINARY(16)
+
+    python_type = uuid.UUID
+
+    def __init__(self, binary=True, native=True, **kwargs):
+        """
+        :param binary: Whether to use a BINARY(16) or CHAR(32) fallback.
+
+        """
+        self.binary = binary
+        self.native = native
+
+    def __repr__(self):
+        return util.generic_repr(self)
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == 'postgresql' and self.native:
+            # Use the native UUID type.
+            return dialect.type_descriptor(postgresql.UUID())
+
+        if dialect.name == 'mssql' and self.native:
+            # Use the native UNIQUEIDENTIFIER type.
+            return dialect.type_descriptor(mssql.UNIQUEIDENTIFIER())
+
+        else:
+            # Fallback to either a BINARY or a CHAR.
+            kind = self.impl if self.binary else types.CHAR(32)
+            return dialect.type_descriptor(kind)
+
+    @staticmethod
+    def _coerce(value):
+        if value and not isinstance(value, uuid.UUID):
+            try:
+                value = uuid.UUID(value)
+
+            except (TypeError, ValueError):
+                value = uuid.UUID(bytes=value)
+
+        return value
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+
+        if not isinstance(value, uuid.UUID):
+            value = self._coerce(value)
+
+        if self.native and dialect.name in ('postgresql', 'mssql'):
+            return str(value)
+
+        return value.bytes if self.binary else value.hex
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+
+        if self.native and dialect.name in ('postgresql', 'mssql'):
+            if isinstance(value, uuid.UUID):
+                # Some drivers convert PostgreSQL's uuid values to
+                # Python's uuid.UUID objects by themselves
+                return value
+            return uuid.UUID(value)
+
+        return uuid.UUID(bytes=value) if self.binary else uuid.UUID(value)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-sqlite"
-version = "0.25.0"
+version = "0.26.0"
 
 setup(
     name=project,
@@ -19,7 +19,6 @@ setup(
     python_requires=">=3.6",
     keywords="microcosm",
     install_requires=[
-        "SQLAlchemy-Utils>=0.33.3",
         "SQLAlchemy>=1.2.0",
         "alembic>=1.0.11",
         "microcosm>=2.12.0",


### PR DESCRIPTION
**Why?**
SQLAlchemy-utils is currently not compatible with SQLAlchemy > 1.4.0, which results in following error:
```
from sqlalchemy.orm.query import _ColumnEntity
ImportError: cannot import name '_ColumnEntity' from 'sqlalchemy.orm.query'
```

**What?**
Copied UUIDType from SQLAlchemy-utils into microcosm-sqlite codebase and removed SQLAlchemy-util from dependencies.
